### PR TITLE
Update documentation on installing openalpr on mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Tiny rubygem wrapping [openALPR](https://github.com/openalpr/openalpr).
 
-You'll need to install openALPR. I used `brew tap brewsci/science && brew install openalpr`, on macOS. 
+You'll need to install openALPR. I used `brew update && brew install openalpr`, on macOS. 
 
 For Linux see the [official wiki](https://github.com/openalpr/openalpr/wiki/Compilation-instructions-(Ubuntu-Linux))
 


### PR DESCRIPTION
The homebrew package has been removed from the homebrew-science tap to homebrew-core as the former is no longer maintained

migrating to homebrew-core: Homebrew/homebrew-core#67822
remove from homebrew-science: brewsci/homebrew-science#265